### PR TITLE
Corrected the order of steps in App Initial Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ _(In a #channel)_
 
 1. [Create a new Slack app](https://api.slack.com/apps/new).
 2. Name your app `rota` and select your preferred development Slack workspace.
-3. Under **App Home**, make sure your bot and app's name are `rota`.
+3. In the **OAuth & Permissions** section, add "Bot Token Scopes" for `app_mentions:read`, `chat:write`, and `incoming-webhook`.
+4. Under **App Home**, make sure your bot and app's name are `rota`.
   * Toggle on "Always Show My Bot as Online".
   * Enable the Home Tab.
   * Enable the Messages Tab.
-4. Under **Incoming Webhooks**, click the toggle to switch "Activate Incoming Webhooks" `On`.
-5. In the **OAuth & Permissions** section, add "Bot Token Scopes" for `app_mentions:read`, `chat:write`, and `incoming-webhook`.
+5. Under **Incoming Webhooks**, click the toggle to switch "Activate Incoming Webhooks" `On`.
 6. Under **Install App**, click the "Install App" button to install to your team workspace. When prompted, choose a channel to install to (it can be any channel.) This will generate a "Bot User OAuth Access Token" (which you will need in order to configure your local environment variables). The token will be displayed after you've installed your app. _Note that if you update any Scopes later, you'll have to reinstall your app._
 
 ### Database Setup


### PR DESCRIPTION
You can not enable tabs in your app before you have added scopes.